### PR TITLE
Made DoorModelIndex public

### DIFF
--- a/Assets/Scripts/API/DFBlock.cs
+++ b/Assets/Scripts/API/DFBlock.cs
@@ -566,7 +566,7 @@ namespace DaggerfallConnect
             public Int16 OpenRotation;
 
             /// <summary>Model index to use for door as offset from base door ID.</summary>
-            internal Byte DoorModelIndex;
+            public Byte DoorModelIndex;
 
             /// <summary>Unknown.</summary>
             internal Byte Unknown;


### PR DESCRIPTION
This solves an issue I discovered and reported which causes all doors inside the overridden block to use model 9000.

Fixes Interkarma/daggerfall-unity#1989